### PR TITLE
Allow $NEXTDATA to be $ENDDATA+1

### DIFF
--- a/fcsparser/api.py
+++ b/fcsparser/api.py
@@ -258,8 +258,14 @@ class FCSParser(object):
         text = self.annotation
         keys = text.keys()
 
-        if '$NEXTDATA' in text and text['$NEXTDATA'] != 0:
-            raise ParserFeatureNotImplementedError('Not implemented $NEXTDATA is not 0')
+        if '$NEXTDATA' in text:
+            if text['$NEXTDATA'] != 0 and '$ENDDATA' in text:
+                nextdata = int(text['$NEXTDATA'])
+                enddata = int(text['$ENDDATA'])
+                if nextdata != enddata+1:
+                    raise_parser_feature_not_implemented('Not implemented $NEXTDATA is not 0 and is not $ENDDATA+1')
+            else:
+                raise_parser_feature_not_implemented('Not implemented $NEXTDATA is not 0 and is not $ENDDATA+1')
 
         if '$MODE' not in text or text['$MODE'] != 'L':
             raise ParserFeatureNotImplementedError('Mode not implemented')

--- a/fcsparser/api.py
+++ b/fcsparser/api.py
@@ -227,7 +227,7 @@ class FCSParser(object):
         # unused currently but keep for debugging
         # keys_encoding_range = ['$P{0}R'.format(i) for i in self.channel_numbers]
 
-        add_keys_to_convert_to_int = ['$NEXTDATA', '$ENDDATA', '$PAR', '$TOT']
+        add_keys_to_convert_to_int = ['$NEXTDATA', '$PAR', '$TOT']
 
         keys_to_convert_to_int = keys_encoding_bits + add_keys_to_convert_to_int
 
@@ -275,7 +275,7 @@ class FCSParser(object):
         if '$NEXTDATA' in text and text['$NEXTDATA'] != 0:
             if '$ENDDATA' in text:
                 nextdata = text['$NEXTDATA']
-                enddata = text['$ENDDATA']
+                enddata = int(text['$ENDDATA'])
                 if nextdata != enddata+1:
                     logging.error('This file has multiple datasets, $NEXTDATA must equal to $ENDDATA+1')
                 else:

--- a/fcsparser/api.py
+++ b/fcsparser/api.py
@@ -263,9 +263,9 @@ class FCSParser(object):
                 nextdata = int(text['$NEXTDATA'])
                 enddata = int(text['$ENDDATA'])
                 if nextdata != enddata+1:
-                    raise_parser_feature_not_implemented('Not implemented $NEXTDATA is not 0 and is not $ENDDATA+1')
+                    ParserFeatureNotImplementedError('Not implemented $NEXTDATA is not 0 and is not $ENDDATA+1')
             else:
-                raise_parser_feature_not_implemented('Not implemented $NEXTDATA is not 0 and is not $ENDDATA+1')
+                ParserFeatureNotImplementedError('Not implemented $NEXTDATA is not 0 and is not $ENDDATA+1')
 
         if '$MODE' not in text or text['$MODE'] != 'L':
             raise ParserFeatureNotImplementedError('Mode not implemented')

--- a/fcsparser/api.py
+++ b/fcsparser/api.py
@@ -227,7 +227,7 @@ class FCSParser(object):
         # unused currently but keep for debugging
         # keys_encoding_range = ['$P{0}R'.format(i) for i in self.channel_numbers]
 
-        add_keys_to_convert_to_int = ['$NEXTDATA', '$PAR', '$TOT']
+        add_keys_to_convert_to_int = ['$NEXTDATA', '$ENDDATA', '$PAR', '$TOT']
 
         keys_to_convert_to_int = keys_encoding_bits + add_keys_to_convert_to_int
 
@@ -272,15 +272,16 @@ class FCSParser(object):
         text = self.annotation
         keys = text.keys()
 
-        if '$NEXTDATA' in text:
-           if int(text['$NEXTDATA']) != 0:
-                if '$ENDDATA' in text:
-                    nextdata = int(text['$NEXTDATA'])
-                    enddata = int(text['$ENDDATA'])
-                    if nextdata != enddata+1:
-                        raise ParserFeatureNotImplementedError('Not implemented $NEXTDATA is not 0 or $NEXTDATA != $ENDDATA+1 ')
+        if '$NEXTDATA' in text and text['$NEXTDATA'] != 0:
+            if '$ENDDATA' in text:
+                nextdata = text['$NEXTDATA']
+                enddata = text['$ENDDATA']
+                if nextdata != enddata+1:
+                    logging.error('This file has multiple datasets, $NEXTDATA must equal to $ENDDATA+1')
                 else:
-                    logging.error('$NEXTDATA is not 0, this file has multiple datasets')
+                    logging.info('This file has multiple datasets')
+            else:
+                logging.error('This file has multiple datasets, $ENDDATA not defined')
 
 
         if '$MODE' not in text or text['$MODE'] != 'L':


### PR DESCRIPTION
FCS files generated with Millipore  have $NEXTDATA equals to $ENDDATA+1 instead of 0s
