### PR TITLE
Cloning an fcs file for disk write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+*.pyc

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,17 @@ Using
     >>> path = fcsparser.test_sample_path
     >>> meta, data = fcsparser.parse(path, reformat_meta=True)
 
+Using to clone an fcs file and modify data
+
+    >>> from fcsparser.api import FCSParser
+    >>> path = fcsparse.test_sample_path
+    >>> fcs_file = FCSParser(path)
+    >>> subset_fcs_file = fcs_file.clone(data=fcs_file.data[:1000]
+    >>> subset_fcs_file.write_to_file('/tmp/subset_fcs_file.fcs')
+
+If no data is passed in to `clone`, the entirety of the existing data will be used
+in the clone.
+
 A more detailed example can be found here: http://nbviewer.ipython.org/github/eyurtsev/fcsparser/blob/master/doc/fcsparser_example.ipynb
 
 

--- a/fcsparser/__init__.py
+++ b/fcsparser/__init__.py
@@ -5,4 +5,3 @@ from fcsparser.api import parse
 
 test_sample_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
     'tests', 'data', 'FlowCytometers', 'HTS_BD_LSR-II', 'HTS_BD_LSR_II_Mixed_Specimen_001_D6_D06.fcs')
-


### PR DESCRIPTION
This allows you to clone an existing FCSParser so as to modify the
annotation or data and then write the new FCSParser to disk.