### PR TITLE
Update fromfile to support 3-byte fields

### DIFF
--- a/fcsparser/api.py
+++ b/fcsparser/api.py
@@ -27,11 +27,39 @@ logger = logging.getLogger(__name__)
 
 def fromfile(file, dtype, count, *args, **kwargs):
     """Wrapper around np.fromfile to support any file-like object."""
+    
+    dtypes = dtype.split(',')
+    field_width = []
+    
+    for dt in dtypes:
+        num_bytes = int(dt[2:])
+        field_width.append(num_bytes)
+        
     try:
-        return numpy.fromfile(file, dtype=dtype, count=count, *args, **kwargs)
+        ret = numpy.fromfile(file, 
+                             dtype=",".join(['u1'] * sum(field_width)), 
+                             count=count, 
+                             *args, 
+                             **kwargs)
     except (TypeError, IOError):
-        return numpy.frombuffer(file.read(count * numpy.dtype(dtype).itemsize),
-                                dtype=dtype, count=count, *args, **kwargs)
+        ret = numpy.frombuffer(file.read(count * sum(field_width)),
+                               dtype=",".join(['u1'] * sum(field_width)), 
+                               count=count, 
+                               *args, 
+                               **kwargs)
+
+    ret = ret.view('u1').reshape((count, sum(field_width)))
+    ret_dtypes = []
+    for field, dt in enumerate(dtypes):
+        dtype_type = dt[1]
+        dtype_endian = dt[0]
+        num_bytes = int(dt[2:])
+        while num_bytes & (num_bytes - 1) != 0:
+            ret = np.insert(ret, sum(field_width[0:field]), np.zeros(count), axis = 1)
+            num_bytes = num_bytes + 1
+        ret_dtypes.append(dtype_endian + dtype_type + str(num_bytes))
+
+    return ret.view(','.join(ret_dtypes)).ravel()
 
 
 class ParserFeatureNotImplementedError(Exception):


### PR DESCRIPTION
Some FCS files (such as the one generated by the Cytek xP5) store integers in 3-byte fields.  This breaks numpy's parser, which only wants power-of-two sized fields.  So, I've updated fromfile() to parse FCS files as a table of 1-byte unsigned ints, expand those fields to 4 bytes, and then re-view them as the proper dtype.

My only concern is that this may break on an FCS file produced by a big-endian machine (because I'm adding the extra bytes to the beginning of the field).  I don't have ready access to any of those -- do you?