### PR TITLE
Bugfix: Handle repeated TEXT delimiter

### DIFF
--- a/fcsparser/api.py
+++ b/fcsparser/api.py
@@ -206,7 +206,7 @@ class FCSParser(object):
                        u'and end of TEXT segment'.format(raw_text[:2], raw_text[-2:]))
                 raise ParserFeatureNotImplementedError(msg)
 
-        # Delimiters are "quoted" by being repeated (two consecutive delimiters). This code splits
+        # The delimiter is escaped by being repeated (two consecutive delimiters). This code splits
         # on the escaped delimiter first, so there is no need for extra logic to distinguish
         # actual delimiters from escaped delimiters.
         nested_split_list = [x.split(delimiter) for x in raw_text[1:-1].split(delimiter * 2)]

--- a/fcsparser/api.py
+++ b/fcsparser/api.py
@@ -208,10 +208,6 @@ class FCSParser(object):
         # Below 1:-1 used to remove first and last characters which should be reserved for delimiter
         # Also, the delimiter is "quoted" by being repeated (two consecutive delimiters)
         delimiter_split_arr = [x.split(delimiter) for x in raw_text[1:-1].split(delimiter * 2)]
-        #print(delimiter)
-        #print(delimiter * 2)
-        #print(raw_text[1:-1].split(delimiter * 2))
-        #print(delimiter_split_arr)
 
         raw_text_segments = delimiter_split_arr[0]
         for part in delimiter_split_arr[1:]:

--- a/fcsparser/api.py
+++ b/fcsparser/api.py
@@ -210,9 +210,9 @@ class FCSParser(object):
         delimiter_split_arr = [x.split(delimiter) for x in raw_text[1:-1].split(delimiter * 2)]
 
         raw_text_segments = delimiter_split_arr[0]
-        for part in delimiter_split_arr[1:]:
-            raw_text_segments[-1] += (delimiter + part[0])
-            raw_text_segments.extend(part[1:])
+        for partial_segment in delimiter_split_arr[1:]:
+            raw_text_segments[-1] += (delimiter + partial_segment[0])
+            raw_text_segments.extend(partial_segment[1:])
 
         keys, values = raw_text_segments[0::2], raw_text_segments[1::2]
         text = {key: value for key, value in zip(keys, values)}  # build dictionary

--- a/fcsparser/tests/test_fcs_reader.py
+++ b/fcsparser/tests/test_fcs_reader.py
@@ -260,19 +260,6 @@ class TestFCSReader(unittest.TestCase):
         self.assertListEqual(channel_names, pns_names)
         self.assertListEqual(list(data.columns.values), pns_names)
 
-    def test_channel_naming_automatic_correction(self):
-        """Check that channel names are automatically corrected if duplicated names exist."""
-        file_path = ADDITIONAL_FILE_MAPPING['duplicate_names']
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-            meta = parse_fcs(file_path, meta_data_only=True, reformat_meta=True)
-            channel_names = list(meta['_channel_names_'])
-            expected_channel_names = ['HDR-CE', 'HDR-SE', 'HDR-V', 'FSC-A', 'FSC-H',
-                                      'SSC-A', 'SSC-H', 'FL7-A', 'FL7-H']
-            self.assertListEqual(expected_channel_names, channel_names)
-
     def test_speed_of_reading_fcs_files(self):
         """Test the speed of loading a FCS files"""
         file_path = FILE_IDENTIFIER_TO_PATH['mq fcs 3.1']

--- a/fcsparser/tests/test_fcs_reader.py
+++ b/fcsparser/tests/test_fcs_reader.py
@@ -72,6 +72,12 @@ class TestFCSReader(unittest.TestCase):
         meta = parse_fcs(fname, meta_data_only=True)
         self.assertEqual('MACSQuant', meta['$CYT'])
 
+    def test_repeated_delimiter_text_segment(self):
+        parser = FCSParser()
+        raw_text = '/flow_speed/3 m//s/x/a///y/b/////'
+        text = parser._extract_text_dict(raw_text)
+        self.assertDictEqual(text, {'flow_speed': '3 m/s', 'x': 'a/', 'y': 'b//'})
+
     def test_mq_FCS_2_0_data_segment(self):
         """Test DATA segment parsed from FCS (2.0 format) file from a MACSQuant flow cytometer"""
         values = array([[1.60764902830123901367e-03, 1.46554875373840332031e+00,


### PR DESCRIPTION
First, thanks for creating and maintaining this package! I use it a lot.

I discovered a bug in how the TEXT segment is parsed. A repeated delimiter is supposed to represent a single delimiter in the decoded strings (see item 3.2.7 of the [3.1 standard](http://software.broadinstitute.org/cancer/software/genepattern/attachments/fcs_3_1_standard.pdf)). For example, the key-value pair `{'flow_speed': '3 m/s'}` with the delimiter `/` should be encoded as:
`/flow_speed/3 m//s/`.
This string is currently decoded in fcsparser as:
`{'flow_speed': '3 m', '': 's'}`

The code in this PR should handle the delimiter correctly. It's not quite ready to merge yet, though. It appears that the test FCS file with duplicate column names actually just had the delimiter in the names, causing them to be read incorrectly. This means the corresponding test is now failing. If there are other real examples of FCS files with duplicate column names, we should swap one out. If not, perhaps the test can be deleted. What do you think?

A couple notes:
1) The same delimiter logic is described in the FCS 2.0 standard, so this change theoretically shouldn't cause any compatibility issues
2) I moved some of the surrounding code into a function just to make it more easily testable - the actual addition is only a few lines.