### PR TITLE
parse TEXT segments that don't end with a delimiter

### DIFF
--- a/fcsparser/_version.py
+++ b/fcsparser/_version.py
@@ -1,1 +1,1 @@
-version = "0.2.1bt1"
+version = "0.2.1+bt1"

--- a/fcsparser/_version.py
+++ b/fcsparser/_version.py
@@ -1,1 +1,1 @@
-version = "0.2.1"
+version = "0.2.1bt1"

--- a/fcsparser/api.py
+++ b/fcsparser/api.py
@@ -209,14 +209,20 @@ class FCSParser(object):
             if raw_text[-1] != delimiter:
                 msg = (u'The first two characters were:\n {}. The last two characters were: {}\n'
                        u'Parser expects the same delimiter character in beginning '
-                       u'and end of TEXT segment'.format(raw_text[:2], raw_text[-2:]))
-                raise ParserFeatureNotImplementedError(msg)
+                       u'and end of TEXT segment. This file may be parsed incorrectly!'.format(raw_text[:2], raw_text[-2:]))
+                warnings.warn(msg)
+                raw_text = raw_text[1:]
+            else:
+                raw_text = raw_text[1:-1]
+        else:
+            raw_text = raw_text[1:-1]
+            
+        # 1:-1 above removes the first and last characters which are reserved for the delimiter.
 
         # The delimiter is escaped by being repeated (two consecutive delimiters). This code splits
         # on the escaped delimiter first, so there is no need for extra logic to distinguish
         # actual delimiters from escaped delimiters.
-        nested_split_list = [x.split(delimiter) for x in raw_text[1:-1].split(delimiter * 2)]
-        # 1:-1 above removes the first and last characters which are reserved for the delimiter.
+        nested_split_list = [x.split(delimiter) for x in raw_text.split(delimiter * 2)]
 
         # Flatten the nested list to a list of elements (alternating keys and values)
         raw_text_elements = nested_split_list[0]


### PR DESCRIPTION
Hi @eyurtsev ! I keep coming across "challenging" FCS files from weird instruments and software.  Most I can handle at a higher level, but apparently the Cytek NL-2000 produces FCS files whose TEXT segment does NOT end with a delimiter (but is otherwise conformant.)  

I'll attach an example file -- I propose handling it by changing the error at https://github.com/eyurtsev/fcsparser/blob/5b33e1bdcbfaf58964565150c8e17530dd5f8076/fcsparser/api.py#L210 to a warning, and allowing the TEXT segment to end without a delimiter. (Yes, I know the FCS standard is explicit about this, but what are we going to do?....)

Let me know what you think.  Thanks!  -Brian

[Cytek NL-2000.zip](https://github.com/eyurtsev/fcsparser/files/6896767/Cytek.NL-2000.zip)
