### PR TITLE
fcs_reader: Bump dev requirements

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-numpy==1.13.1
-pandas==0.20.3
-pytest==3.2.1
-pytest-cov==2.5.1
+numpy==1.21.1
+pandas==1.3.1
+pytest==6.2.4
+pytest-cov==2.12.1


### PR DESCRIPTION
dev requirements are only used to make sure the local dev requirement is locked (at least somewhat)
