### PR TITLE
Make __init__.py use a relative import

### DIFF
--- a/fcsparser/__init__.py
+++ b/fcsparser/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-from fcsparser.api import parse
+from .api import parse
 
 test_sample_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
     'tests', 'data', 'FlowCytometers', 'HTS_BD_LSR-II', 'HTS_BD_LSR_II_Mixed_Specimen_001_D6_D06.fcs')


### PR DESCRIPTION
Instead of making `cytoflow` depend on `fcsparser`, I would like to include `fcsparser` as a submodule. This way, if I have fixes that I want to roll out with a `cytoflow` release, I don't have to wait on you to roll a new release of `fcsparser`.  (Making new releases is harder than it should be.)

This would be a lot easier on my end if `fcsparser.__init__` used a relative import instead of an absolute import. This way, the directory containing `api.py` doesn't have to be in `sys.path`.  It should not effect folks who use `fcsparser` directly.