### PR TITLE
Fix unsafe loading from file buffer

### DIFF
--- a/fcsparser/api.py
+++ b/fcsparser/api.py
@@ -68,13 +68,18 @@ def fromfile(file, dtype, count, *args, **kwargs):
             file, dtype=",".join(["u1"] * record_width), count=count, *args, **kwargs
         )
     except (TypeError, IOError):
-        ret = numpy.frombuffer(
+        _ret = numpy.frombuffer(
             file.read(count * record_width),
             dtype=",".join(["u1"] * record_width),
             count=count,
             *args,
             **kwargs
         )
+        # Create a copy of the file content as `numpy.frombuffer`
+        # returns a view into the original object which is not 
+        # safe for mutable file buffers.
+        # See https://numpy.org/doc/stable/reference/generated/numpy.frombuffer.html
+        ret = _ret.copy()
 
     # convert the DATA segment from a 1 x `count` array of records
     # (and remember, each record is composed of `record_width`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fcsparser"
-version = "0.2.6"
+version = "0.2.7"
 description = "A python package for reading raw fcs files"
 authors = ["Eugene Yurtsev <eyurtsev@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fcsparser"
-version = "0.2.7"
+version = "0.2.6"
 description = "A python package for reading raw fcs files"
 authors = ["Eugene Yurtsev <eyurtsev@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
The [numpy documentation](https://numpy.org/doc/stable/reference/generated/numpy.frombuffer.html) states for numpy.frombuffer` that:
> This function creates a view into the original object.
> This should be safe in general, but it may make sense to copy
> the result when the original object is mutable or untrusted.

When the filebuffer is mutable a `ValueError: output array is read-only` is raised in:
https://github.com/eyurtsev/fcsparser/blob/701000af178e36e0dedb53d409119c25675b9d16/fcsparser/api.py#L590